### PR TITLE
refactor: remove yarn references from build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "prebuild": "tsc --project tsconfig.mapbox.json && tsc --project tsconfig.maplibre.json",
-    "build": "yarn build:maplibre && yarn build:mapbox",
+    "build": "npm run build:maplibre && npm run build:mapbox",
     "build:maplibre": "cross-env LIB_MODE=1 MAP_MODE=0 vite build",
     "postbuild:maplibre": "cross-env LIB_MODE=2 MAP_MODE=0 vite build",
     "build:mapbox": "cross-env LIB_MODE=1 MAP_MODE=1 vite build",


### PR DESCRIPTION
## Summary
- Removed remaining yarn references from package.json build scripts
- Changed `yarn build:maplibre` and `yarn build:mapbox` to use `npm run` instead
- Aligns with project requirement for Node >=20 and npm-only approach

## Changes
- Updated `build` script in package.json to use `npm run` instead of `yarn`

## Testing
- [ ] Run `npm run build` to verify the build process works correctly
- [ ] Run `npm run build:storybook` to ensure Storybook builds properly

🤖 Generated with [Claude Code](https://claude.ai/code)