### PR TITLE
Fix package name references to @wendylabsinc/react-three-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ import React, { useRef, useState } from 'react'
 import { useFrame } from "@react-three/fiber"
 import { useRef, useState } from "react"
 import Map from "react-map-gl/maplibre"
-import { Canvas } from "react-three-map/maplibre" 
-// import { Canvas } from "react-three-map" // if you are using MapBox
+import { Canvas } from "@wendylabsinc/react-three-map/maplibre"
+// import { Canvas } from "@wendylabsinc/react-three-map" // if you are using MapBox
 
 function BasicExample() {
   return <Map
@@ -140,8 +140,8 @@ Same as in `@react-three/fiber`, the `<Canvas>` object is where you start to def
 ```tsx
 import "maplibre-gl/dist/maplibre-gl.css"
 import Map from "react-map-gl/maplibre"
-import { Canvas } from 'react-three-map/maplibre'
-// import { Canvas } from "react-three-map" // if you are using MapBox
+import { Canvas } from '@wendylabsinc/react-three-map/maplibre'
+// import { Canvas } from "@wendylabsinc/react-three-map" // if you are using MapBox
 
 const App = () => (
   <Map 
@@ -202,7 +202,7 @@ This component allows you to have 3D objects at different coordinates.
 
 
 ```tsx
-import { Canvas, Coordinates } from 'react-three-map'
+import { Canvas, Coordinates } from '@wendylabsinc/react-three-map'
 
 <Canvas latitude={51} longitude={0}>
   <Coordinates latitude={50} longitude={0}>
@@ -232,11 +232,11 @@ Check the story to see the difference between the two or check #102 for more inf
 
 ### useMap
 
-Access the map from inside `react-three-map`.
+Access the map from inside `@wendylabsinc/react-three-map`.
 
 ```tsx
-import { useMap } from "react-three-map";
-// import { useMap } from "react-three-map/maplibre"; if you use maplibre
+import { useMap } from "@wendylabsinc/react-three-map";
+// import { useMap } from "@wendylabsinc/react-three-map/maplibre"; if you use maplibre
 const Component = () => {
   const map = useMap();
   return <>...</>
@@ -288,7 +288,7 @@ These utilities enable creating, storing, and querying 3D geofences. Convert Thr
 Converts a Three.js BufferGeometry to PostGIS `POLYHEDRALSURFACE Z` WKT format for database storage.
 
 ```tsx
-import { bufferGeometryToWKT } from 'react-three-map/maplibre';
+import { bufferGeometryToWKT } from '@wendylabsinc/react-three-map/maplibre';
 import { BoxGeometry } from 'three';
 
 // Define the geofence origin (Canvas position)
@@ -317,7 +317,7 @@ Returns a WKT string in `POLYHEDRALSURFACE Z ((...))` format.
 Parses a PostGIS `POLYHEDRALSURFACE Z` WKT string back into a Three.js BufferGeometry.
 
 ```tsx
-import { wktToBufferGeometry } from 'react-three-map/maplibre';
+import { wktToBufferGeometry } from '@wendylabsinc/react-three-map/maplibre';
 
 // Load WKT from database
 const wkt = await fetchGeofenceFromDB();
@@ -344,7 +344,7 @@ Returns a Three.js `BufferGeometry`.
 Tests whether a geographic coordinate is inside a 3D geofence volume.
 
 ```tsx
-import { isCoordsInPolyhedron } from 'react-three-map/maplibre';
+import { isCoordsInPolyhedron } from '@wendylabsinc/react-three-map/maplibre';
 import { BoxGeometry } from 'three';
 
 const origin = { latitude: 51.5074, longitude: -0.1278, altitude: 0 };
@@ -386,7 +386,7 @@ Returns `{ inside: boolean, intersectionCount: number }`.
 A gizmo component for translating and rotating 3D objects in map space. Provides intuitive controls with translation arrows (red=X, green=Y, blue=Z) and rotation rings for each axis.
 
 ```tsx
-import { Canvas, EnhancedPivotControls, useMap } from 'react-three-map/maplibre';
+import { Canvas, EnhancedPivotControls, useMap } from '@wendylabsinc/react-three-map/maplibre';
 import { Matrix4, Vector3, Euler } from 'three';
 import { useMemo, useState, useCallback } from 'react';
 
@@ -461,7 +461,7 @@ function DraggableObject() {
 A 3D compass component that displays cardinal directions (N, S, E, W) and vertical orientation (Up, Down). By default renders as a HUD overlay that tracks the camera.
 
 ```tsx
-import { Canvas, Compass3D } from 'react-three-map/maplibre';
+import { Canvas, Compass3D } from '@wendylabsinc/react-three-map/maplibre';
 
 // Basic usage - auto-syncs with camera as HUD overlay
 function MapWithCompass() {
@@ -515,7 +515,7 @@ A screen-space compass overlay that renders in its own React Three Fiber canvas.
 
 ```tsx
 import Map from 'react-map-gl/maplibre';
-import { CompassOverlay } from 'react-three-map/maplibre';
+import { CompassOverlay } from '@wendylabsinc/react-three-map/maplibre';
 
 function App() {
   return (

--- a/docs-src/compass.md
+++ b/docs-src/compass.md
@@ -7,7 +7,7 @@ The `Compass3D` component displays a 3D compass that shows cardinal directions (
 The simplest way to add a compass is to use the default overlay mode, which automatically positions the compass in the corner of your canvas:
 
 ```tsx
-import { Canvas, Compass3D } from 'react-three-map/maplibre';
+import { Canvas, Compass3D } from '@wendylabsinc/react-three-map/maplibre';
 import Map from 'react-map-gl/maplibre';
 
 function App() {
@@ -63,7 +63,7 @@ Adjust the compass size and proportions:
 For a compass that exists in 3D world space rather than as a screen overlay, disable overlay mode and provide manual bearing/pitch values:
 
 ```tsx
-import { Canvas, Compass3D, useMap } from 'react-three-map/maplibre';
+import { Canvas, Compass3D, useMap } from '@wendylabsinc/react-three-map/maplibre';
 import { useState, useEffect } from 'react';
 
 function WorldSpaceCompass() {
@@ -119,7 +119,7 @@ The compass follows the library's axis convention:
 For advanced use cases, the `CompassOverlay` component renders the compass in a separate React Three Fiber canvas that floats above the map. This can be useful when you want complete control over the compass rendering:
 
 ```tsx
-import { CompassOverlay } from 'react-three-map';
+import { CompassOverlay } from '@wendylabsinc/react-three-map';
 import Map, { useMap } from 'react-map-gl/maplibre';
 
 function App() {

--- a/docs-src/getting-started.md
+++ b/docs-src/getting-started.md
@@ -27,7 +27,7 @@ MapLibre is a free, open-source fork of Mapbox GL JS. No access token required.
 ```tsx
 import "maplibre-gl/dist/maplibre-gl.css";
 import Map from "react-map-gl/maplibre";
-import { Canvas } from "react-three-map/maplibre";
+import { Canvas } from "@wendylabsinc/react-three-map/maplibre";
 
 function App() {
   return (
@@ -61,7 +61,7 @@ Mapbox requires an access token from [mapbox.com](https://www.mapbox.com/).
 ```tsx
 import "mapbox-gl/dist/mapbox-gl.css";
 import Map from "react-map-gl/mapbox";
-import { Canvas } from "react-three-map";
+import { Canvas } from "@wendylabsinc/react-three-map";
 
 function App() {
   return (

--- a/docs-src/interacting-with-map.md
+++ b/docs-src/interacting-with-map.md
@@ -7,7 +7,7 @@ This guide covers how to interact with the underlying map from your Three.js com
 The `useMap` hook gives you access to the MapLibre or Mapbox map instance.
 
 ```tsx
-import { useMap } from "react-three-map/maplibre";
+import { useMap } from "@wendylabsinc/react-three-map/maplibre";
 
 function MapController() {
   const map = useMap();
@@ -35,7 +35,7 @@ function MapController() {
 You can subscribe to map events like zoom, pan, and rotation changes.
 
 ```tsx
-import { useMap } from "react-three-map/maplibre";
+import { useMap } from "@wendylabsinc/react-three-map/maplibre";
 import { useEffect, useState } from "react";
 
 function ZoomIndicator() {
@@ -89,7 +89,7 @@ function AnimatedObject() {
 Useful for loading data only for the visible area:
 
 ```tsx
-import { useMap } from "react-three-map/maplibre";
+import { useMap } from "@wendylabsinc/react-three-map/maplibre";
 import { useEffect } from "react";
 
 function VisibleAreaLoader() {
@@ -122,7 +122,7 @@ function VisibleAreaLoader() {
 You can combine map interaction with React Three Fiber hooks:
 
 ```tsx
-import { useMap } from "react-three-map/maplibre";
+import { useMap } from "@wendylabsinc/react-three-map/maplibre";
 import { useFrame } from "@react-three/fiber";
 import { useRef } from "react";
 

--- a/docs-src/multiple-locations.md
+++ b/docs-src/multiple-locations.md
@@ -16,7 +16,7 @@ react-three-map provides two components for positioning objects at different coo
 The `Coordinates` component creates a separate, properly-scaled scene at each location. Use this when objects are far apart.
 
 ```tsx
-import { Canvas, Coordinates } from "react-three-map/maplibre";
+import { Canvas, Coordinates } from "@wendylabsinc/react-three-map/maplibre";
 
 function WorldMarkers() {
   return (
@@ -54,7 +54,7 @@ function WorldMarkers() {
 The `NearCoordinates` component is more performant but only translates position without scale correction. Use this for objects within the same city or region.
 
 ```tsx
-import { Canvas, NearCoordinates } from "react-three-map/maplibre";
+import { Canvas, NearCoordinates } from "@wendylabsinc/react-three-map/maplibre";
 
 function CityMarkers() {
   const locations = [
@@ -93,7 +93,7 @@ For more control, use the utility functions directly:
 Converts geographic coordinates to a 3D position relative to an origin.
 
 ```tsx
-import { coordsToVector3 } from "react-three-map/maplibre";
+import { coordsToVector3 } from "@wendylabsinc/react-three-map/maplibre";
 
 function DynamicMarker({ targetLat, targetLng }) {
   const origin = { latitude: 51.5074, longitude: -0.1278 };
@@ -115,7 +115,7 @@ function DynamicMarker({ targetLat, targetLng }) {
 Converts a 3D position back to geographic coordinates. Useful after user interactions.
 
 ```tsx
-import { vector3ToCoords, coordsToVector3 } from "react-three-map/maplibre";
+import { vector3ToCoords, coordsToVector3 } from "@wendylabsinc/react-three-map/maplibre";
 import { useState } from "react";
 
 function DraggableMarker() {

--- a/docs-src/pivot-controls.md
+++ b/docs-src/pivot-controls.md
@@ -13,7 +13,7 @@ The `EnhancedPivotControls` component provides an intuitive gizmo for translatin
 ## Basic Usage
 
 ```tsx
-import { Canvas, EnhancedPivotControls, useMap } from 'react-three-map/maplibre';
+import { Canvas, EnhancedPivotControls, useMap } from '@wendylabsinc/react-three-map/maplibre';
 import { Matrix4, Vector3, Euler } from 'three';
 import { useState, useMemo, useCallback } from 'react';
 
@@ -208,7 +208,7 @@ function MultiObjectEditor() {
 After moving an object, you can convert its position back to lat/lng:
 
 ```tsx
-import { vector3ToCoords } from 'react-three-map/maplibre';
+import { vector3ToCoords } from '@wendylabsinc/react-three-map/maplibre';
 
 const onDrag = (m4: Matrix4) => {
   const position = new Vector3().setFromMatrixPosition(m4);

--- a/example-mapbox/src/canvas.basic.stories.tsx
+++ b/example-mapbox/src/canvas.basic.stories.tsx
@@ -4,7 +4,7 @@ import Mapbox from "mapbox-gl";
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { FC, PropsWithChildren, useRef, useState } from "react";
 import Map from 'react-map-gl/mapbox';
-import { Canvas } from "react-three-map";
+import { Canvas } from "@wendylabsinc/react-three-map";
 import { Mesh } from "three";
 
 export default { title: 'Mapbox Examples/Canvas' }

--- a/example-mapbox/src/comparison.stories.tsx
+++ b/example-mapbox/src/comparison.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { MapControls } from "@react-three/drei";
 import { Canvas as FiberCanvas } from "@react-three/fiber";
-import { Canvas } from "react-three-map/mapbox";
+import { Canvas } from "@wendylabsinc/react-three-map/mapbox";
 import { MyScene } from "./my-scene";
 import { StoryMap } from "./story-map-storybook";
 import { useControls } from "leva";

--- a/example-mapbox/src/html-on-top.stories.tsx
+++ b/example-mapbox/src/html-on-top.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Box, Html } from "@react-three/drei";
 import { useState } from "react";
-import { Canvas } from "react-three-map/mapbox";
+import { Canvas } from "@wendylabsinc/react-three-map/mapbox";
 import { MathUtils } from "three";
 import { StoryMap } from "./story-map-storybook";
 

--- a/example-mapbox/src/render-on-demand.stories.tsx
+++ b/example-mapbox/src/render-on-demand.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Box, Stats } from "@react-three/drei";
 import { useRef, useState } from "react";
-import { Canvas } from "react-three-map/mapbox";
+import { Canvas } from "@wendylabsinc/react-three-map/mapbox";
 import { MathUtils } from "three";
 import { StoryMap } from "./story-map-storybook";
 

--- a/example-maplibre/src/canvas.basic.stories.tsx
+++ b/example-maplibre/src/canvas.basic.stories.tsx
@@ -2,7 +2,7 @@ import { useFrame, Vector3 } from "@react-three/fiber";
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { FC, useRef, useState } from "react";
 import Map from 'react-map-gl/maplibre';
-import { Canvas } from "react-three-map/maplibre";
+import { Canvas } from "@wendylabsinc/react-three-map/maplibre";
 import { Mesh } from "three";
 
 export default { title: 'MapLibre Examples/Canvas' }

--- a/example-maplibre/src/comparison.stories.tsx
+++ b/example-maplibre/src/comparison.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { MapControls } from "@react-three/drei";
 import { Canvas as FiberCanvas } from "@react-three/fiber";
 import { useControls } from "leva";
-import { Canvas } from "react-three-map/maplibre";
+import { Canvas } from "@wendylabsinc/react-three-map/maplibre";
 import { MyScene } from "./my-scene";
 import { StoryMap } from "./story-map-storybook";
 

--- a/example-maplibre/src/html-on-top.stories.tsx
+++ b/example-maplibre/src/html-on-top.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Box, Html } from "@react-three/drei";
 import { useState } from "react";
-import { Canvas } from "react-three-map/maplibre";
+import { Canvas } from "@wendylabsinc/react-three-map/maplibre";
 import { MathUtils } from "three";
 import { StoryMap } from "./story-map-storybook";
 

--- a/example-maplibre/src/render-on-demand.stories.tsx
+++ b/example-maplibre/src/render-on-demand.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Box, Stats } from "@react-three/drei";
 import { useRef, useState } from "react";
-import { Canvas } from "react-three-map/maplibre";
+import { Canvas } from "@wendylabsinc/react-three-map/maplibre";
 import { MathUtils } from "three";
 import { StoryMap } from "./story-map-storybook";
 

--- a/src/api/coordinates.tsx
+++ b/src/api/coordinates.tsx
@@ -40,7 +40,7 @@ export interface CoordinatesProps extends PropsWithChildren {
  *
  * @example
  * ```tsx
- * import { Canvas, Coordinates } from 'react-three-map/maplibre';
+ * import { Canvas, Coordinates } from '@wendylabsinc/react-three-map/maplibre';
  *
  * function App() {
  *   return (

--- a/src/api/coords-to-vector-3.ts
+++ b/src/api/coords-to-vector-3.ts
@@ -56,7 +56,7 @@ export function averageMercatorScale(originLat: number, pointLat: number, steps 
  *
  * @example
  * ```ts
- * import { coordsToVector3 } from 'react-three-map/maplibre';
+ * import { coordsToVector3 } from '@wendylabsinc/react-three-map/maplibre';
  *
  * const origin = { latitude: 51.5074, longitude: -0.1278 }; // London
  * const point = { latitude: 51.5080, longitude: -0.1270, altitude: 50 };

--- a/src/api/near-coordinates.tsx
+++ b/src/api/near-coordinates.tsx
@@ -21,7 +21,7 @@ import { coordsToVector3 } from "./coords-to-vector-3";
  *
  * @example
  * ```tsx
- * import { Canvas, NearCoordinates } from 'react-three-map/maplibre';
+ * import { Canvas, NearCoordinates } from '@wendylabsinc/react-three-map/maplibre';
  *
  * function CityMarkers() {
  *   const locations = [

--- a/src/api/point-in-polyhedron.ts
+++ b/src/api/point-in-polyhedron.ts
@@ -47,7 +47,7 @@ const BOUNDARY_TOLERANCE = 1e-3;
  *
  * @example
  * ```ts
- * import { isPointInPolyhedron } from 'react-three-map/maplibre';
+ * import { isPointInPolyhedron } from '@wendylabsinc/react-three-map/maplibre';
  * import { BoxGeometry } from 'three';
  *
  * const box = new BoxGeometry(100, 100, 100);
@@ -156,7 +156,7 @@ export function isPointInPolyhedron(
  *
  * @example
  * ```ts
- * import { isCoordsInPolyhedron } from 'react-three-map/maplibre';
+ * import { isCoordsInPolyhedron } from '@wendylabsinc/react-three-map/maplibre';
  *
  * const origin = { latitude: 51.5074, longitude: -0.1278, altitude: 0 };
  * const testPoint = { latitude: 51.5080, longitude: -0.1270, altitude: 25 };
@@ -189,7 +189,7 @@ export function isCoordsInPolyhedron(
  *
  * @example
  * ```ts
- * import { isCoordsInGeoTriangles } from 'react-three-map/maplibre';
+ * import { isCoordsInGeoTriangles } from '@wendylabsinc/react-three-map/maplibre';
  *
  * // Triangles loaded from database
  * const triangles = JSON.parse(storedGeoJson);
@@ -276,7 +276,7 @@ export function isPointInGeoTriangles(
  *
  * @example
  * ```ts
- * import { isPointOnSurface } from 'react-three-map/maplibre';
+ * import { isPointOnSurface } from '@wendylabsinc/react-three-map/maplibre';
  * import { BoxGeometry } from 'three';
  *
  * const box = new BoxGeometry(100, 100, 100);

--- a/src/api/polyhedral-surface.ts
+++ b/src/api/polyhedral-surface.ts
@@ -197,7 +197,7 @@ function toGeoVertex(tuple: Vector3Tuple, origin: Coords): GeoVertex {
  *
  * @example
  * ```ts
- * import { extractGeoTriangles } from 'react-three-map/maplibre';
+ * import { extractGeoTriangles } from '@wendylabsinc/react-three-map/maplibre';
  * import { BoxGeometry } from 'three';
  *
  * const geometry = new BoxGeometry(100, 100, 100);
@@ -301,7 +301,7 @@ export function extractGeoTriangles(
  *
  * @example
  * ```ts
- * import { bufferGeometryToWKT } from 'react-three-map/maplibre';
+ * import { bufferGeometryToWKT } from '@wendylabsinc/react-three-map/maplibre';
  * import { BoxGeometry } from 'three';
  *
  * const geometry = new BoxGeometry(100, 100, 100);
@@ -367,7 +367,7 @@ export function bufferGeometryToWKT(
  *
  * @example
  * ```ts
- * import { wktToBufferGeometry } from 'react-three-map/maplibre';
+ * import { wktToBufferGeometry } from '@wendylabsinc/react-three-map/maplibre';
  *
  * const wkt = 'POLYHEDRALSURFACE Z (((-0.1 51.5 0, -0.1 51.6 0, -0.2 51.5 0, -0.1 51.5 0)))';
  * const origin = { latitude: 51.5074, longitude: -0.1278, altitude: 0 };
@@ -503,7 +503,7 @@ export function parsePolyhedralSurfaceWKT(wkt: string): GeoTriangle[] {
  *
  * @example
  * ```ts
- * import { bufferGeometryToGeoTriangles } from 'react-three-map/maplibre';
+ * import { bufferGeometryToGeoTriangles } from '@wendylabsinc/react-three-map/maplibre';
  *
  * const triangles = bufferGeometryToGeoTriangles(geometry, origin);
  * const json = JSON.stringify(triangles);
@@ -527,7 +527,7 @@ export function bufferGeometryToGeoTriangles(
  *
  * @example
  * ```ts
- * import { geoTrianglesToBufferGeometry } from 'react-three-map/maplibre';
+ * import { geoTrianglesToBufferGeometry } from '@wendylabsinc/react-three-map/maplibre';
  *
  * const json = await fetchFromDatabase();
  * const triangles = JSON.parse(json);

--- a/src/api/use-map.ts
+++ b/src/api/use-map.ts
@@ -12,8 +12,8 @@ import { MapInstance } from "../core/generic-map";
  *
  * @example
  * ```tsx
- * import { useMap } from 'react-three-map/maplibre';
- * // or: import { useMap } from 'react-three-map'; // for Mapbox
+ * import { useMap } from '@wendylabsinc/react-three-map/maplibre';
+ * // or: import { useMap } from '@wendylabsinc/react-three-map'; // for Mapbox
  *
  * function MyComponent() {
  *   const map = useMap();

--- a/src/api/vector-3-to-coords.ts
+++ b/src/api/vector-3-to-coords.ts
@@ -23,7 +23,7 @@ import { earthRadius } from "../core/earth-radius";
  *
  * @example
  * ```ts
- * import { vector3ToCoords, coordsToVector3 } from 'react-three-map/maplibre';
+ * import { vector3ToCoords, coordsToVector3 } from '@wendylabsinc/react-three-map/maplibre';
  *
  * const origin = { latitude: 51.5074, longitude: -0.1278 };
  *

--- a/src/components/compass-3d.tsx
+++ b/src/components/compass-3d.tsx
@@ -160,7 +160,7 @@ export interface Compass3DProps {
  *
  * @example Basic compass synced with map
  * ```tsx
- * import { Canvas, Compass3D, useMap } from 'react-three-map/maplibre';
+ * import { Canvas, Compass3D, useMap } from '@wendylabsinc/react-three-map/maplibre';
  *
  * function MapWithCompass() {
  *   const map = useMap();

--- a/src/components/compass-overlay.tsx
+++ b/src/components/compass-overlay.tsx
@@ -61,7 +61,7 @@ export interface CompassOverlayProps {
  * @example Basic usage inside a Map
  * ```tsx
  * import Map from 'react-map-gl/maplibre';
- * import { CompassOverlay } from 'react-three-map/maplibre';
+ * import { CompassOverlay } from '@wendylabsinc/react-three-map/maplibre';
  *
  * function App() {
  *   return (

--- a/src/components/enhanced-pivot-controls.tsx
+++ b/src/components/enhanced-pivot-controls.tsx
@@ -705,7 +705,7 @@ const AxisArrow: React.FC<{
  *
  * @example
  * ```tsx
- * import { Canvas, EnhancedPivotControls, useMap } from 'react-three-map/maplibre';
+ * import { Canvas, EnhancedPivotControls, useMap } from '@wendylabsinc/react-three-map/maplibre';
  * import { Matrix4, Vector3, Euler } from 'three';
  *
  * function DraggableObject() {

--- a/src/mapbox.index.ts
+++ b/src/mapbox.index.ts
@@ -5,13 +5,13 @@
  * Use this when working with Mapbox GL JS and `react-map-gl/mapbox`.
  *
  * @packageDocumentation
- * @module react-three-map
+ * @module @wendylabsinc/react-three-map
  *
  * @example
  * ```tsx
  * import "mapbox-gl/dist/mapbox-gl.css";
  * import Map from "react-map-gl/mapbox";
- * import { Canvas, Coordinates, useMap, coordsToVector3 } from "react-three-map";
+ * import { Canvas, Coordinates, useMap, coordsToVector3 } from "@wendylabsinc/react-three-map";
  *
  * function App() {
  *   return (
@@ -50,7 +50,7 @@ export type { CompassOverlayProps } from './components/compass-overlay';
  *
  * @example
  * ```tsx
- * import { useMap } from "react-three-map";
+ * import { useMap } from "@wendylabsinc/react-three-map";
  *
  * function MyComponent() {
  *   const map = useMap();

--- a/src/mapbox/canvas.tsx
+++ b/src/mapbox/canvas.tsx
@@ -28,7 +28,7 @@ const fromLngLat = MercatorCoordinate.fromLngLat
  * ```tsx
  * import "mapbox-gl/dist/mapbox-gl.css";
  * import Map from "react-map-gl/mapbox";
- * import { Canvas } from "react-three-map";
+ * import { Canvas } from "@wendylabsinc/react-three-map";
  *
  * function App() {
  *   return (

--- a/src/maplibre.index.ts
+++ b/src/maplibre.index.ts
@@ -5,13 +5,13 @@
  * Use this when working with MapLibre GL JS and `react-map-gl/maplibre`.
  *
  * @packageDocumentation
- * @module react-three-map/maplibre
+ * @module @wendylabsinc/react-three-map/maplibre
  *
  * @example
  * ```tsx
  * import "maplibre-gl/dist/maplibre-gl.css";
  * import Map from "react-map-gl/maplibre";
- * import { Canvas, Coordinates, useMap, coordsToVector3 } from "react-three-map/maplibre";
+ * import { Canvas, Coordinates, useMap, coordsToVector3 } from "@wendylabsinc/react-three-map/maplibre";
  *
  * function App() {
  *   return (
@@ -49,7 +49,7 @@ export type { CompassOverlayProps } from './components/compass-overlay';
  *
  * @example
  * ```tsx
- * import { useMap } from "react-three-map/maplibre";
+ * import { useMap } from "@wendylabsinc/react-three-map/maplibre";
  *
  * function MyComponent() {
  *   const map = useMap();

--- a/src/maplibre/canvas.tsx
+++ b/src/maplibre/canvas.tsx
@@ -28,7 +28,7 @@ const fromLngLat = MercatorCoordinate.fromLngLat
  * ```tsx
  * import "maplibre-gl/dist/maplibre-gl.css";
  * import Map from "react-map-gl/maplibre";
- * import { Canvas } from "react-three-map/maplibre";
+ * import { Canvas } from "@wendylabsinc/react-three-map/maplibre";
  *
  * function App() {
  *   return (

--- a/stories/src/adaptive-dpr.tsx
+++ b/stories/src/adaptive-dpr.tsx
@@ -1,6 +1,6 @@
 import { useThree } from "@react-three/fiber";
 import { memo, useEffect, useState } from "react";
-import { useMap } from "react-three-map";
+import { useMap } from "@wendylabsinc/react-three-map";
 
 export const AdaptiveDpr = memo(() => {
   const initialDpr = useThree(s => s.viewport.initialDpr)

--- a/stories/src/buffer-geometry-editor.stories.tsx
+++ b/stories/src/buffer-geometry-editor.stories.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import type { Meta } from '@storybook/react'
 import { StoryMap } from './story-map-storybook'
-import { Coordinates } from 'react-three-map'
+import { Coordinates } from '@wendylabsinc/react-three-map'
 import { Box, Sphere, Cone, Plane } from '@react-three/drei'
 import { useControls, button } from 'leva'
 import * as THREE from 'three'

--- a/stories/src/canvas/mapbox.stories.tsx
+++ b/stories/src/canvas/mapbox.stories.tsx
@@ -4,7 +4,7 @@ import MapboxGl from "mapbox-gl";
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { FC, PropsWithChildren, useRef, useState } from "react";
 import Map from 'react-map-gl/mapbox';
-import { Canvas } from "react-three-map/mapbox";
+import { Canvas } from "@wendylabsinc/react-three-map/mapbox";
 import { Mesh } from "three";
 
 export default { title: 'Canvas' }

--- a/stories/src/canvas/maplibre.stories.tsx
+++ b/stories/src/canvas/maplibre.stories.tsx
@@ -3,7 +3,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { FC, useRef, useState } from "react";
 import Map from 'react-map-gl/maplibre';
 import { Mesh } from "three";
-import { Canvas } from "react-three-map/maplibre";
+import { Canvas } from "@wendylabsinc/react-three-map/maplibre";
 import { Leva } from "leva";
 
 export default { title: 'Canvas' }

--- a/stories/src/compass-3d.stories.tsx
+++ b/stories/src/compass-3d.stories.tsx
@@ -1,6 +1,6 @@
 import { Canvas } from "@react-three/fiber";
 import { useControls } from "leva";
-import { Compass3D, CompassOverlay } from "react-three-map";
+import { Compass3D, CompassOverlay } from "@wendylabsinc/react-three-map";
 import { StoryMap } from "./story-map-storybook";
 
 // Main story component

--- a/stories/src/enhanced-pivot-controls.stories.tsx
+++ b/stories/src/enhanced-pivot-controls.stories.tsx
@@ -3,10 +3,10 @@ import { useControls } from "leva";
 import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { Marker as MapboxMarker } from "react-map-gl/mapbox";
 import { Marker as MaplibreMarker } from "react-map-gl/maplibre";
-import { useMap, vector3ToCoords } from "react-three-map";
+import { useMap, vector3ToCoords } from "@wendylabsinc/react-three-map";
 import { Euler, Matrix4, Vector3, Vector3Tuple } from "three";
 import { StoryMap } from "./story-map-storybook";
-import { EnhancedPivotControls } from "react-three-map";
+import { EnhancedPivotControls } from "@wendylabsinc/react-three-map";
 
 export function EnhancedPivotStory() {
   const origin = useControls({

--- a/stories/src/extrude/extrude-coordinates.stories.tsx
+++ b/stories/src/extrude/extrude-coordinates.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from '@storybook/react';
 import { Environment, Extrude, Html } from "@react-three/drei";
 import { useMemo } from "react";
-import { Coords, coordsToVector3 } from "react-three-map";
+import { Coords, coordsToVector3 } from "@wendylabsinc/react-three-map";
 import { MathUtils, Shape, Vector2Tuple } from "three";
 import { StoryMap } from "../story-map-storybook";
 import { Chaillot } from "./chaillot";

--- a/stories/src/free-3d-buildings/batched-buildings.tsx
+++ b/stories/src/free-3d-buildings/batched-buildings.tsx
@@ -1,6 +1,6 @@
 import { Object3DNode, extend, useFrame } from "@react-three/fiber";
 import { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Coords, coordsToVector3 } from "react-three-map";
+import { Coords, coordsToVector3 } from "@wendylabsinc/react-three-map";
 import { suspend } from "suspend-react";
 import { BatchedMesh, Color, ExtrudeGeometry, MathUtils, Shape, Vector3Tuple } from "three";
 import { BatchedStandardMaterial } from "./batched-standard-material/batched-standard-material";

--- a/stories/src/free-3d-buildings/buildings-3d.stories.tsx
+++ b/stories/src/free-3d-buildings/buildings-3d.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta } from '@storybook/react';
 // import { Bloom, EffectComposer } from '@react-three/postprocessing'; // Temporarily disabled
 import { levaStore, useControls } from "leva";
 import { Suspense, useEffect } from "react";
-import { Coords } from "react-three-map";
+import { Coords } from "@wendylabsinc/react-three-map";
 // import { ScreenBlend } from "../screen-blend-effect/screen-blend"; // Part of post-processing, temporarily disabled
 import { StoryMap } from "../story-map-storybook";
 import { BatchedBuildings } from "./batched-buildings";

--- a/stories/src/free-3d-buildings/get-buildings-data.ts
+++ b/stories/src/free-3d-buildings/get-buildings-data.ts
@@ -1,4 +1,4 @@
-import { Coords } from "react-three-map";
+import { Coords } from "@wendylabsinc/react-three-map";
 
 export interface OverpassElement {
   type: "node" | "way" | "relation";

--- a/stories/src/mapbox/story-mapbox.tsx
+++ b/stories/src/mapbox/story-mapbox.tsx
@@ -3,7 +3,7 @@ import Mapbox from "mapbox-gl";
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { FC, PropsWithChildren, memo } from "react";
 import Map, { Layer } from 'react-map-gl/mapbox';
-import { Canvas } from 'react-three-map/mapbox';
+import { Canvas } from '@wendylabsinc/react-three-map/mapbox';
 import { StoryMapProps } from '../story-map-storybook';
 
 /** `<Map>` styled for stories */

--- a/stories/src/maplibre/story-maplibre.tsx
+++ b/stories/src/maplibre/story-maplibre.tsx
@@ -3,7 +3,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { FC, memo, useEffect, useRef } from "react";
 import Map, { useMap, NavigationControl, TerrainControl } from 'react-map-gl/maplibre';
 import { StoryMapProps } from '../story-map-storybook';
-import { Canvas } from 'react-three-map/maplibre';
+import { Canvas } from '@wendylabsinc/react-three-map/maplibre';
 
 // Component to setup terrain after map loads
 const TerrainSetup: FC<{ terrain?: any }> = ({ terrain }) => {

--- a/stories/src/multi-coordinates.stories.tsx
+++ b/stories/src/multi-coordinates.stories.tsx
@@ -3,7 +3,7 @@ import { Box } from "@react-three/drei";
 import { Vector3 } from "@react-three/fiber";
 import { levaStore, useControls } from "leva";
 import { FC, useEffect, useState } from "react";
-import { Coordinates, CoordinatesProps, NearCoordinates } from "react-three-map";
+import { Coordinates, CoordinatesProps, NearCoordinates } from "@wendylabsinc/react-three-map";
 import { ColorRepresentation } from "three";
 import { StoryMap } from "./story-map-storybook";
 

--- a/stories/src/story-map-storybook.tsx
+++ b/stories/src/story-map-storybook.tsx
@@ -7,8 +7,8 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { FC, PropsWithChildren, ReactElement, ReactNode, cloneElement, isValidElement } from "react";
 import MapboxMap from 'react-map-gl/mapbox';
 import MaplibreMap from 'react-map-gl/maplibre';
-import { Canvas as MapboxCanvas, CanvasProps } from 'react-three-map/mapbox';
-import { Canvas as MaplibreCanvas } from 'react-three-map/maplibre';
+import { Canvas as MapboxCanvas, CanvasProps } from '@wendylabsinc/react-three-map/mapbox';
+import { Canvas as MaplibreCanvas } from '@wendylabsinc/react-three-map/maplibre';
 
 export enum MapProvider {
   maplibre = "maplibre",

--- a/stories/src/sunlight/sunlight.stories.tsx
+++ b/stories/src/sunlight/sunlight.stories.tsx
@@ -3,7 +3,7 @@ import { Billboard, Line, Plane, Ring, Sphere, useHelper } from "@react-three/dr
 import { useFrame } from "@react-three/fiber";
 import { useControls } from "leva";
 import { RefObject, memo, useEffect, useMemo, useRef } from "react";
-import { useMap } from "react-three-map";
+import { useMap } from "@wendylabsinc/react-three-map";
 import { getPosition } from "suncalc";
 import { BufferAttribute, BufferGeometry, CameraHelper, Color, MathUtils, OrthographicCamera, PCFSoftShadowMap, Vector3Tuple } from "three";
 import { ScreenSizer } from "../screen-sizer";

--- a/stories/src/terrain-bigSur.stories.tsx
+++ b/stories/src/terrain-bigSur.stories.tsx
@@ -1,9 +1,9 @@
 import { Cone } from "@react-three/drei";
 import { useControls } from "leva";
 import { FC, useCallback, useEffect, useMemo, useState } from "react";
-import { useMap } from "react-three-map";
+import { useMap } from "@wendylabsinc/react-three-map";
 import { Euler, Matrix4, Vector3, Vector3Tuple } from "three";
-import { EnhancedPivotControls } from "react-three-map";
+import { EnhancedPivotControls } from "@wendylabsinc/react-three-map";
 import { StoryMap } from "./story-map-storybook";
 
 // Back to Big Sur coordinates - AWS terrain tiles have global coverage

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,9 +33,9 @@ export default defineConfig({
       resolve: {
         alias: {
           '@': resolve(__dirname, './src'),
-          'react-three-map/maplibre': resolve(__dirname, './src/maplibre.index.ts'),
-          'react-three-map/mapbox': resolve(__dirname, './src/mapbox.index.ts'),
-          'react-three-map': resolve(__dirname, './src/mapbox.index.ts'),
+          '@wendylabsinc/react-three-map/maplibre': resolve(__dirname, './src/maplibre.index.ts'),
+          '@wendylabsinc/react-three-map/mapbox': resolve(__dirname, './src/mapbox.index.ts'),
+          '@wendylabsinc/react-three-map': resolve(__dirname, './src/mapbox.index.ts'),
         }
       }
     }


### PR DESCRIPTION
## Summary

- Update all imports, documentation, and examples to use the correct scoped package name `@wendylabsinc/react-three-map` instead of `react-three-map`
- Fix vite.config.ts aliases to use scoped package name for local development
- Update README.md code examples with correct import paths

## Changes

- **vite.config.ts**: Update aliases from `react-three-map` to `@wendylabsinc/react-three-map`
- **Stories**: Fix all story file imports (45 files total)
- **Examples**: Fix example-mapbox and example-maplibre imports
- **README.md**: Update all code examples with correct package name
- **docs-src/**: Update all markdown documentation files
- **Source code**: Update JSDoc comments with correct import examples

## Test plan

- [ ] Run `npm run dev` and verify Storybook loads correctly
- [ ] Verify imports resolve properly with the updated vite aliases
- [ ] Check that documentation examples show the correct package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)