### PR TITLE
Fix MapLibre compass overlay sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # react-three-map
 
+## 1.0.8
+
+### Patch Changes
+
+- Fix MapLibre compass overlay to subscribe to the active map and keep bearing/pitch in sync.
+- Guard R3M initialization to avoid setState during render and handle absent `fromLngLat` safely.
+- Use provider-specific compass overlays in Storybook so MapLibre stories stay interactive.
+
 ## 1.0.0
 
 ### Major Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wendylabsinc/react-three-map",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wendylabsinc/react-three-map",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.26.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wendylabsinc/react-three-map",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A React wrapper library for Google Maps 3D with React Three Fiber integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api/coordinates.tsx
+++ b/src/api/coordinates.tsx
@@ -76,9 +76,11 @@ export const Coordinates = memo<CoordinatesProps>(({
   const r3m = useR3M();
 
   const origin = useCoordsToMatrix({
-    latitude, longitude, altitude, fromLngLat: r3m.fromLngLat,
+    latitude, longitude, altitude, fromLngLat: r3m?.fromLngLat,
   });
 
+
+  if (!r3m) return null;
 
   return <>{createPortal(<>
     <RenderAtCoords r3m={r3m} origin={origin} />

--- a/src/core/canvas-overlay/canvas-portal.tsx
+++ b/src/core/canvas-overlay/canvas-portal.tsx
@@ -48,6 +48,7 @@ export const CanvasPortal = memo<CanvasPortalProps>(({
       setOnRender={setOnRender}
       onReady={onReady}
       map={map}
+      fromLngLat={fromLngLat}
     />
     {ready && children}
   </Canvas>

--- a/src/core/use-coords-to-matrix.ts
+++ b/src/core/use-coords-to-matrix.ts
@@ -1,13 +1,20 @@
 import { useMemo } from "react";
+import { Matrix4 } from "three";
 import { coordsToMatrix } from "./coords-to-matrix";
+import { FromLngLat } from "./generic-map";
 
-type Props = Parameters<typeof coordsToMatrix>[0];
+type Props = Omit<Parameters<typeof coordsToMatrix>[0], 'fromLngLat'> & { fromLngLat?: FromLngLat };
+
+const identity = new Matrix4().identity().toArray();
 
 /** calculate matrix from coordinates */
 export function useCoordsToMatrix({latitude, longitude, altitude, fromLngLat}: Props) {
-  const m4 = useMemo(() => coordsToMatrix({
-    latitude, longitude, altitude, fromLngLat,
-  }), [latitude, longitude, altitude, fromLngLat]);
+  const m4 = useMemo(() => {
+    if (!fromLngLat) return identity;
+    return coordsToMatrix({
+      latitude, longitude, altitude, fromLngLat,
+    })
+  }, [latitude, longitude, altitude, fromLngLat]);
 
   return m4;
 }

--- a/src/core/use-r3m.ts
+++ b/src/core/use-r3m.ts
@@ -1,5 +1,5 @@
 import { _roots, useThree } from "@react-three/fiber";
-import { useState } from "react";
+import { useEffect } from "react";
 import { Matrix4, Matrix4Tuple } from "three";
 import { FromLngLat, MapInstance } from "./generic-map";
 
@@ -15,7 +15,7 @@ export interface R3M<T extends MapInstance = MapInstance> {
 }
 
 export function useR3M<T extends MapInstance> () {
-  const r3m = useThree(s=>(s as any).r3m) as R3M<T>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const r3m = useThree(s=>(s as any).r3m) as R3M<T> | undefined; // eslint-disable-line @typescript-eslint/no-explicit-any
   return r3m;
 }
 
@@ -24,11 +24,13 @@ export function useInitR3M<T extends MapInstance>(props: {
   map: T; fromLngLat: FromLngLat;
 }) {
   const canvas = useThree(s => s.gl.domElement);
-  // to run only once
-  useState(()=>{
-    const store = _roots.get(canvas)!.store; // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    initR3M({...props, store})
-  })
+  const { map, fromLngLat } = props;
+  // Initialise R3M after the canvas exists to avoid setState during render
+  useEffect(() => {
+    const root = _roots.get(canvas);
+    if (!root) return;
+    initR3M({ map, fromLngLat, store: root.store });
+  }, [canvas, map, fromLngLat]);
 }
 
 export function initR3M<T extends MapInstance>({store, ...props}: {

--- a/src/maplibre/compass-overlay.tsx
+++ b/src/maplibre/compass-overlay.tsx
@@ -93,15 +93,22 @@ export function CompassOverlay({
   className,
   overlay = true,
 }: CompassOverlayProps) {
-  const { current: map } = useMap();
+  const maps = useMap();
+  const map = useMemo(() => {
+    const collection = maps ? Object.values(maps).filter(Boolean) : [];
+    // Prefer explicit current/default keys, then fall back to the first map in the collection
+    return (maps as any)?.current || (maps as any)?.default || collection[0];
+  }, [maps]);
   const [bearing, setBearing] = useState(0);
   const [pitch, setPitch] = useState(0);
   const mapRef = useRef(map);
   mapRef.current = map;
 
   useEffect(() => {
-    if (!mapRef.current) return;
-    const m = mapRef.current;
+    const mapLike = mapRef.current;
+    if (!mapLike) return;
+    // MapRef exposes getMap(); Map exposes bearing/pitch directly
+    const m = typeof (mapLike as any).getMap === 'function' ? (mapLike as any).getMap() : mapLike;
     const update = () => {
       setBearing(m.getBearing());
       setPitch(m.getPitch());
@@ -110,12 +117,14 @@ export function CompassOverlay({
     m.on('move', update);
     m.on('rotate', update);
     m.on('pitch', update);
+    m.on('render', update);
     return () => {
       m.off('move', update);
       m.off('rotate', update);
       m.off('pitch', update);
+      m.off('render', update);
     };
-  }, []);
+  }, [map]);
 
   // Camera looking down from above; we keep the default up vector so screen-up aligns to world +Y.
   const camera = useMemo(() => ({

--- a/stories/src/compass-3d.stories.tsx
+++ b/stories/src/compass-3d.stories.tsx
@@ -1,6 +1,7 @@
 import { Canvas } from "@react-three/fiber";
 import { useControls } from "leva";
-import { Compass3D, CompassOverlay } from "@wendylabsinc/react-three-map";
+import { Compass3D, CompassOverlay as MapboxCompassOverlay } from "@wendylabsinc/react-three-map";
+import { CompassOverlay as MaplibreCompassOverlay } from "@wendylabsinc/react-three-map/maplibre";
 import { StoryMap } from "./story-map-storybook";
 
 // Main story component
@@ -119,16 +120,17 @@ export function TerrainWith3DCompass() {
         latitude={origin.latitude}
         longitude={origin.longitude}
         zoom={11}
-        pitch={60}
-        bearing={0}
-        maplibreStyle={maplibreStyle}
-        mapboxStyle={mapboxStyle}
-        mapChildren={<CompassOverlay />}
-      >
-        {/* No other 3D objects in the scene, just the terrain */}
-      </StoryMap>
-    </div>
-  );
+      pitch={60}
+      bearing={0}
+      maplibreStyle={maplibreStyle}
+      mapboxStyle={mapboxStyle}
+      mapboxChildren={<MapboxCompassOverlay />}
+      maplibreChildren={<MaplibreCompassOverlay />}
+    >
+      {/* No other 3D objects in the scene, just the terrain */}
+    </StoryMap>
+  </div>
+);
 }
 
 // Standalone compass story for testing


### PR DESCRIPTION
## Summary
- guard R3M init/coords usage to avoid setState-in-render and missing fromLngLat failures
- fix MapLibre compass overlay to subscribe to the active map and update on render; use provider-specific overlay in Storybook
- bump version to 1.0.8 and document changes

## Testing
- not run (not requested)